### PR TITLE
Handle network failures when building word lists

### DIFF
--- a/App/models/cwordurl.py
+++ b/App/models/cwordurl.py
@@ -3,13 +3,26 @@ from bs4 import BeautifulSoup
 from nltk.corpus import words
 
 
+class CwordurlFetchError(Exception):
+    """Raised when failing to fetch the provided URL."""
+
+
 class Cwordurl:
     def __init__(self, url):
         self.__is_word = {}
         self.__not_word = {}
-        self.__soup = BeautifulSoup(requests.get(url).content, 'html.parser')
-        self.__dat = self.__prepocess()
-        self.__process()
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            self.__soup = BeautifulSoup(response.content, 'html.parser')
+        except requests.RequestException as exc:
+            # Keep empty results and signal failure
+            self.__soup = BeautifulSoup('', 'html.parser')
+            self.__dat = {}
+            raise CwordurlFetchError(f"Failed to fetch URL: {url}") from exc
+        else:
+            self.__dat = self.__prepocess()
+            self.__process()
 
     def __prepocess(self):
         s = self.__soup.get_text().split()


### PR DESCRIPTION
## Summary
- handle HTTP errors while fetching URLs
- raise a specific `CwordurlFetchError` when a request fails

## Testing
- `pytest -q`
- `python -m py_compile App/models/cwordurl.py`


------
https://chatgpt.com/codex/tasks/task_e_6853ea276b748325922dc10e24c6effe