### PR TITLE
Rename preprocess method

### DIFF
--- a/App/models/cwordurl.py
+++ b/App/models/cwordurl.py
@@ -8,10 +8,10 @@ class Cwordurl:
         self.__is_word = {}
         self.__not_word = {}
         self.__soup = BeautifulSoup(requests.get(url).content, 'html.parser')
-        self.__dat = self.__prepocess()
+        self.__dat = self.__preprocess()
         self.__process()
 
-    def __prepocess(self):
+    def __preprocess(self):
         s = self.__soup.get_text().split()
         d = {}
         for x in s:


### PR DESCRIPTION
## Summary
- rename `__prepocess` to `__preprocess` in `cwordurl`
- update the constructor to call the renamed method

## Testing
- `pytest -q`
- `python -m py_compile App/models/cwordurl.py`


------
https://chatgpt.com/codex/tasks/task_e_6853e9b1d43c8325a701bbc78dcf3fa7