### PR TITLE
Handle missing URL param in Analyse controller

### DIFF
--- a/App/controllers/analyse.py
+++ b/App/controllers/analyse.py
@@ -11,7 +11,9 @@ class Analyse:
     def index(self):
         ''' index '''
         param = request.form.to_dict()
-        print(param)
+
+        if 'url' not in param:
+            return redirect(url_for('index'))
 
         w = Cwordurl(param['url'])
         wd = {}


### PR DESCRIPTION
## Summary
- avoid logging POST form data in Analyse controller
- redirect to the index page if no URL was posted

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853ebfd53e48325b8064c054c5d131d