### PR TITLE
Fix index page method docstring

### DIFF
--- a/App/controllers/index.py
+++ b/App/controllers/index.py
@@ -6,6 +6,5 @@ import sys
 class Index:
     '''Index'''
     def index(self):
-        '''Returns argument a is squared.'''
-        #crud = CRUD()
+        '''Render the index page.'''
         return render_template('index.html')


### PR DESCRIPTION
## Summary
- clarify the `Index.index` method docstring
- drop outdated comment

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853ec039e44832586a5d6fe58e1319a